### PR TITLE
Add 3 tasks for sass in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,7 @@ var uglify = require('gulp-uglify');
 var merge2 = require('merge2');
 var ignore = require('gulp-ignore');
 var rimraf = require('gulp-rimraf');
+var sourcemaps = require('gulp-sourcemaps');
 var browserSync = require('browser-sync').create();
 
 // Run: 
@@ -55,9 +56,11 @@ gulp.task('watch', function () {
 // Minifies CSS files
 gulp.task('cssnano', ['cleancss'], function(){
   return gulp.src('./css/*.css')
+    .pipe(sourcemaps.init({loadMaps: true}))
     .pipe(plumber())
     .pipe(rename({suffix: '.min'}))
     .pipe(cssnano({discardComments: {removeAll: true}}))
+    .pipe(sourcemaps.write())
     .pipe(gulp.dest('./css/'))
     .pipe(browserSync.stream());
 }); 


### PR DESCRIPTION
I had some issues because of the use of sourcemaps + cssnano together.
I resolved the problem like this :
- The 'scss-for-prod' task to use to create the min.css which is a small file for the prod, but long to compile
- The 'watch-scss' task which is ideal for prod, fast to compile, reload fast and clean sourcemaps

The line :
.pipe(sourcemaps.write(undefined, { sourceRoot: null }))
Is because of this :
scniro/gulp-clean-css#1
and this :
ben-eb/gulp-cssnano#38

The gulp-clone and gulp-merge packages have to be installed.
And the function.php needs to be changed :
- for dev : wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.css', array());
- for prod : wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.min.css', array());

So for me, this tasks replace the 'watch-bs'.


