### PR TITLE
Fix version number in the footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -6,25 +6,26 @@
  *
  * @package understrap
  */
+ $the_theme = wp_get_theme();
 ?>
 
 <?php get_sidebar('footerfull'); ?>
 
 <div class="wrapper" id="wrapper-footer">
-    
+
     <div class="container">
 
         <div class="row">
 
             <div class="col-md-12">
-    
+
                 <footer id="colophon" class="site-footer" role="contentinfo">
 
                     <div class="site-info">
                         <a href="<?php echo esc_url( __( 'http://wordpress.org/', 'understrap' ) ); ?>"><?php printf( __( 'Proudly powered by %s', 'understrap' ), 'WordPress' ); ?></a>
                         <span class="sep"> | </span>
-                        <?php printf( __( 'Theme: %1$s by %2$s.', 'understrap' ), 'understrap', '<a href="http://understrap.com/" rel="designer">understrap.com</a>' ); ?> 
-                        (<?php printf( __( 'Version', 'understrap' ) ); ?>: 0.4.7)
+                        <?php printf( __( 'Theme: %1$s by %2$s.', 'understrap' ), $the_theme->get( 'Name' ), '<a href="http://understrap.com/" rel="designer">understrap.com</a>' ); ?>
+                        (<?php printf( __( 'Version: %1$s', 'understrap' ), $the_theme->get( 'Version' ) ); ?>)
                     </div><!-- .site-info -->
 
                 </footer><!-- #colophon -->
@@ -32,9 +33,9 @@
             </div><!--col end -->
 
         </div><!-- row end -->
-        
+
     </div><!-- container end -->
-    
+
 </div><!-- wrapper end -->
 
 </div><!-- #page -->


### PR DESCRIPTION
It would probably be better to dynamically inject the theme name and version into the footer, no? This method will work with parent or child themes.