### PR TITLE
Fix custom logo function typo

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -29,13 +29,13 @@ add_filter( 'body_class', 'understrap_body_classes' );
 
 add_filter( 'body_class', 'adjust_body_class' );
 function adjust_body_class( $classes ) {
- 
+
     foreach ( $classes as $key => $value ) {
         if ( $value == 'tag' ) unset( $classes[ $key ] );
     }
- 
+
     return $classes;
- 
+
 }
 
 // Filter custom logo with correct classes
@@ -43,6 +43,6 @@ add_filter('get_custom_logo','change_logo_class');
 function change_logo_class($html)
 {
 	$html = str_replace('class="custom-logo"', 'class="img-responsive"', $html);
-	$html = str_replace('class="custom-logo-link"', 'class="navbar-brand" custom-logo-link', $html);
+	$html = str_replace('class="custom-logo-link"', 'class="navbar-brand custom-logo-link"', $html);
 	return $html;
 }


### PR DESCRIPTION
The new custom logo filter has a misplaced quote that results in a stranded 'custom-logo-link' class. This corrects that typo.