### PR TITLE
add support for title live preview in customizer

### DIFF
--- a/js/customizer.js
+++ b/js/customizer.js
@@ -1,0 +1,20 @@
+
+/**
+ * This file adds some LIVE to the Theme Customizer live preview. To leverage
+ * this, set your custom settings to 'postMessage' and then add your handling
+ * here. Your javascript should grab settings from customizer controls, and
+ * then make any necessary changes to the page using jQuery.
+ *
+ * @see https://codex.wordpress.org/Theme_Customization_API#Part_3:_Configure_Live_Preview_.28Optional.29
+ */
+( function( $ ) {
+
+    // Update the site title in real time...
+    wp.customize( 'blogname', function( value ) {
+        value.bind( function( newval ) {
+            console.log(newval);
+            $( '.navbar-header a' ).html( newval );
+        } );
+    } );
+
+} )( jQuery );


### PR DESCRIPTION
This PR adds support for live previewing site's title when using the customizer, in response to @Thomas-A-Reinert https://github.com/holger1411/understrap/issues/103#issuecomment-260404335

The issue was that the native WP has a `#site-title` id and jQuery picks this up in for the update. In understrap this is changed to `.navbar-header` resulting jQuery not been able to find it.

The rest need further investigation.