### PR TITLE
replace deprecated woocommerce function

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -38,7 +38,7 @@ $sidebar_pos = get_theme_mod('understrap_sidebar_position');
 
             //For ANY product archive.
             //Product taxonomy, product search or /shop landing page etc.
-            woocommerce_get_template('archive-product.php');
+              wc_get_template('archive-product.php');
 
           }
         ?>


### PR DESCRIPTION
replaces `woocommerce_get_template` with `wc_get_template` as per Woocommerce documentation:

- https://docs.woocommerce.com/wc-apidocs/function-woocommerce_get_template.html
- https://docs.woocommerce.com/wc-apidocs/function-wc_get_template.html