### PR TITLE
Sidebar left: remove single quotes in the id attribute

### DIFF
--- a/sidebar-left.php
+++ b/sidebar-left.php
@@ -14,9 +14,9 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 ?>
 
 <?php if ( 'both' === $sidebar_pos ): ?>
-<div class="col-md-3 widget-area" id="'left-sidebar'" role="complementary">
+<div class="col-md-3 widget-area" id="left-sidebar" role="complementary">
 	<?php else: ?>
-<div class="col-md-4 widget-area" id="'left-sidebar'" role="complementary">
+<div class="col-md-4 widget-area" id="left-sidebar" role="complementary">
 	<?php endif; ?>
 <?php dynamic_sidebar( 'left-sidebar' ); ?>
 


### PR DESCRIPTION
No need for single quotes in the id attribute.