### PR TITLE
Vertical one page woocommerce fix

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -16,7 +16,15 @@ if ( ! function_exists ( 'understrap_scripts' ) ) {
 		}
 
 		// menu - vertical page association
-		if ( is_page_template( 'page-templates/vertical-one-page.php' ) || is_home() || is_single() ) {
+		// do not load on WooCommerce pages
+		// do not load if we are in WooCommerce pages
+		$loadit = true;
+		if ( class_exists( 'WooCommerce' ) ) {
+			if (is_woocommerce()) {
+				$loadit = false;
+			}
+		}
+		if ( is_page_template( ('page-templates/vertical-one-page.php' ) || is_home() || is_single()) && $loadit ) {
 			wp_enqueue_script( 'vertical-one-page', get_template_directory_uri() . '/js/vertical-one-page.js', array( 'jquery' ), '0.4.9', true );
 			$page_for_posts = strtolower( get_the_title( get_option( 'page_for_posts' ) ) );
 			$home_url       = home_url();

--- a/page-templates/vertical-one-page.php
+++ b/page-templates/vertical-one-page.php
@@ -7,8 +7,8 @@
  * @package understrap
  */
 
- get_header();
- $container = get_theme_mod('understrap_container_type');
+get_header();
+$container = get_theme_mod( 'understrap_container_type' );
 ?>
 
 <?php
@@ -16,38 +16,50 @@
  * Exclude the posts page from being shown in this layout.
  * Order pages by their order number.
  */
- $exclude = get_option( 'page_for_posts' );
- $args    = array(
-  'post_type'    => 'page',
-  'post__not_in' => array( $exclude ),
-  'orderby'      => 'menu_order',
-  'order'        => 'ASC'
- );
+$exclude = array();
+// exclude blog page
+array_push($exclude, get_option( 'page_for_posts' ) );
+// exclude WooCommerce pages
+array_push( $exclude, get_option( 'woocommerce_cart_page_id' ) );
+array_push( $exclude, get_option( 'woocommerce_shop_page_id' ) );
+array_push( $exclude, get_option( 'woocommerce_checkout_page_id' ) );
+array_push( $exclude, get_option( 'woocommerce_pay_page_id' ) );
+array_push( $exclude, get_option( 'woocommerce_thanks_page_id' ) );
+array_push( $exclude, get_option( 'woocommerce_myaccount_page_id' ) );
+array_push( $exclude, get_option( 'woocommerce_edit_address_page_id' ) );
+array_push( $exclude, get_option( 'woocommerce_view_order_page_id' ) );
+array_push( $exclude, get_option( 'woocommerce_terms_page_id' ) );
+$args = array(
+	'post_type'    => 'page',
+	'post__not_in' =>  $exclude,
+	'orderby'      => 'menu_order',
+	'order'        => 'ASC'
+);
 
- $qry = new WP_Query( $args );
+$qry = new WP_Query( $args );
 ?>
 
 <div class="wrapper" id="full-width-page-wrapper">
 
-  <div class="<?php echo $container?>" id="content">
+	<div class="<?php echo $container ?>" id="content">
 
-    <div class="col-md-12 content-area" id="primary">
+		<div class="col-md-12 content-area" id="primary">
 
-      <main class="site-main" id="main" role="main">
+			<main class="site-main" id="main" role="main">
 
-        <?php if ( have_posts() ): while ( $qry->have_posts() ): $qry->the_post() ?>
-          <div class="page">
-            <?php get_template_part( 'loop-templates/content', 'verticalpage' ); ?>
-          </div>
+				<?php if ( have_posts() ): while ( $qry->have_posts() ): $qry->the_post() ?>
+					<div class="page">
+						<?php get_template_part( 'loop-templates/content', 'verticalpage' ); ?>
+					</div>
 
-          <?php wp_reset_postdata(); //reset custom query?>
-        <?php endwhile; endif; ?>
+					<?php wp_reset_postdata(); //reset custom query?>
+				<?php endwhile; endif; ?>
 
-      </main><!-- #main -->
+			</main><!-- #main -->
 
-    </div><!-- #primary -->
+		</div><!-- #primary -->
 
-  </div><!-- Container end -->
+	</div><!-- Container end -->
 
 </div><!-- Wrapper end -->
 


### PR DESCRIPTION
this PR fixes two issues related with the vertical - one page template when the WooCommerce plugin is activated.

* do not load vertical one page related JS file in WooCommerce pages
* do not show WooCommerce pages inside the vertical - one page template