### PR TITLE
Advanced woocommerce integration

### DIFF
--- a/woocommerce/loop/orderby.php
+++ b/woocommerce/loop/orderby.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Show options for ordering
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/loop/orderby.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see 	    https://docs.woocommerce.com/document/template-structure/
+ * @author 		WooThemes
+ * @package 	WooCommerce/Templates
+ * @version     2.2.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+?>
+<form class="woocommerce-ordering" method="get">
+	<select name="orderby" class="orderby custom-select">
+		<?php foreach ( $catalog_orderby_options as $id => $name ) : ?>
+			<option value="<?php echo esc_attr( $id ); ?>" <?php selected( $orderby, $id ); ?>><?php echo esc_html( $name ); ?></option>
+		<?php endforeach; ?>
+	</select>
+	<?php
+		// Keep query string vars intact
+		foreach ( $_GET as $key => $val ) {
+			if ( 'orderby' === $key || 'submit' === $key ) {
+				continue;
+			}
+			if ( is_array( $val ) ) {
+				foreach( $val as $innerVal ) {
+					echo '<input type="hidden" name="' . esc_attr( $key ) . '[]" value="' . esc_attr( $innerVal ) . '" />';
+				}
+			} else {
+				echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( $val ) . '" />';
+			}
+		}
+	?>
+</form>

--- a/woocommerce/single-product/product-thumbnails.php
+++ b/woocommerce/single-product/product-thumbnails.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Single Product Thumbnails
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/single-product/product-thumbnails.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see 	    https://docs.woocommerce.com/document/template-structure/
+ * @author 		WooThemes
+ * @package 	WooCommerce/Templates
+ * @version     2.6.3
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+global $post, $product, $woocommerce;
+
+$attachment_ids = $product->get_gallery_attachment_ids();
+
+if ( $attachment_ids ) {
+	$loop 		= 0;
+	$columns 	= apply_filters( 'woocommerce_product_thumbnails_columns', 3 );
+	?>
+	<div class="thumbnails <?php echo 'columns-' . $columns; ?>"><?php
+
+		foreach ( $attachment_ids as $attachment_id ) {
+
+			$classes = array( 'zoom' );
+
+			if ( $loop === 0 || $loop % $columns === 0 ) {
+				$classes[] = 'first';
+			}
+
+			if ( ( $loop + 1 ) % $columns === 0 ) {
+				$classes[] = 'last';
+			}
+
+			$image_class = implode( ' ', $classes );
+			$props       = wc_get_product_attachment_props( $attachment_id, $post );
+
+			if ( ! $props['url'] ) {
+				continue;
+			}
+
+			echo apply_filters(
+				'woocommerce_single_product_image_thumbnail_html',
+				sprintf(
+					'<a href="%s" class="%s img-thumbnail" title="%s" data-rel="prettyPhoto[product-gallery]">%s</a>',
+					esc_url( $props['url'] ),
+					esc_attr( $image_class ),
+					esc_attr( $props['caption'] ),
+					wp_get_attachment_image( $attachment_id, apply_filters( 'single_product_small_thumbnail_size', 'shop_thumbnail' ), 0, $props )
+				),
+				$attachment_id,
+				$post->ID,
+				esc_attr( $image_class )
+			);
+
+			$loop++;
+		}
+
+	?></div>
+	<?php
+}

--- a/woocommerce/single-product/rating.php
+++ b/woocommerce/single-product/rating.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Single Product Rating
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/single-product/rating.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see 	    https://docs.woocommerce.com/document/template-structure/
+ * @author      WooThemes
+ * @package     WooCommerce/Templates
+ * @version     2.3.2
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+global $product;
+
+if ( get_option( 'woocommerce_enable_review_rating' ) === 'no' ) {
+	return;
+}
+
+$rating_count = $product->get_rating_count();
+$review_count = $product->get_review_count();
+$average      = $product->get_average_rating();
+
+if ( $rating_count > 0 ) : ?>
+
+	<div class="woocommerce-product-rating" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
+		<div class="star-rating text-primary" title="<?php printf( __( 'Rated %s out of 5', 'woocommerce' ), $average ); ?>">
+			<span style="width:<?php echo ( ( $average / 5 ) * 100 ); ?>%">
+				<strong itemprop="ratingValue" class="rating"><?php echo esc_html( $average ); ?></strong> <?php printf( __( 'out of %s5%s', 'woocommerce' ), '<span itemprop="bestRating">', '</span>' ); ?>
+				<?php printf( _n( 'based on %s customer rating', 'based on %s customer ratings', $rating_count, 'woocommerce' ), '<span itemprop="ratingCount" class="rating">' . $rating_count . '</span>' ); ?>
+			</span>
+		</div>
+		<?php if ( comments_open() ) : ?><a href="#reviews" class="woocommerce-review-link" rel="nofollow">(<?php printf( _n( '%s customer review', '%s customer reviews', $review_count, 'woocommerce' ), '<span itemprop="reviewCount" class="count">' . $review_count . '</span>' ); ?>)</a><?php endif ?>
+	</div>
+
+<?php endif; ?>

--- a/woocommerce/single-product/review-rating.php
+++ b/woocommerce/single-product/review-rating.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * The template to display the reviewers star rating in reviews
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/content-product.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @author  WooThemes
+ * @package WooCommerce/Templates
+ * @version 2.6.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+global $comment;
+$rating = intval( get_comment_meta( $comment->comment_ID, 'rating', true ) );
+
+if ( $rating && get_option( 'woocommerce_enable_review_rating' ) === 'yes' ) { ?>
+
+	<div itemprop="reviewRating" itemscope itemtype="http://schema.org/Rating" class="star-rating text-primary" title="<?php echo sprintf( esc_attr__( 'Rated %d out of 5', 'woocommerce' ), esc_attr( $rating ) ) ?>">
+		<span style="width:<?php echo ( esc_attr( $rating ) / 5 ) * 100; ?>%"><strong itemprop="ratingValue"><?php echo esc_attr( $rating ); ?></strong> <?php esc_attr_e( 'out of 5', 'woocommerce' ); ?></span>
+	</div>
+
+<?php }

--- a/woocommerce/single-product/short-description.php
+++ b/woocommerce/single-product/short-description.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Single product short description
+ *
+ * This template can be overridden by copying it to yourtheme/woocommerce/single-product/short-description.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see 	    https://docs.woocommerce.com/document/template-structure/
+ * @author 		WooThemes
+ * @package 	WooCommerce/Templates
+ * @version     1.6.4
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+global $post;
+
+if ( ! $post->post_excerpt ) {
+	return;
+}
+
+?>
+<div itemprop="description" class="lead">
+	<?php echo apply_filters( 'woocommerce_short_description', $post->post_excerpt ) ?>
+</div>


### PR DESCRIPTION
second part of advanced WooCommerce integration, changes:

* on single product page add class `img-thumbnail`
* change product ratings to use `text-primary` color
* on single product page change short description to use `lead` class
* on shop page change the select field used to order products to use class `custom-select`

with these changes, I believe we are past the simple integration offered by `woocommerce.php`. Understrap now provides a more detailed rendering of WooCommerce.