### PR TITLE
blog page as grid

### DIFF
--- a/home.php
+++ b/home.php
@@ -27,9 +27,8 @@ $posts_style = get_theme_mod( 'understrap_posts_index_style' );
 
 			<!-- Do the left sidebar check -->
 			<?php get_template_part( 'global-templates/left-sidebar-check', 'none' ); ?>
-			<?php if ( 'masonry' === $posts_style ): ?>
+			<?php if ( 'masonry' === $posts_style ) : ?>
 			<div class="card-columns"><?php endif; ?>
-
 				<main class="site-main" id="main">
 
 					<?php if ( have_posts() ) : ?>
@@ -39,10 +38,14 @@ $posts_style = get_theme_mod( 'understrap_posts_index_style' );
 						<?php while ( have_posts() ) : the_post(); ?>
 
 							<?php
-							if ( 'masonry' === $posts_style ):
-								get_template_part( 'loop-templates/content-card' );
-							else:
-								/* Include the Post-Format-specific template for the content.
+							if ( 'masonry' === $posts_style ) :
+								get_template_part( 'loop-templates/content', 'card' );
+							elseif ( 'grid' === $posts_style ) :
+
+								get_template_part( 'loop-templates/content', 'grid' );
+							else :
+								/*
+								 * Include the Post-Format-specific template for the content.
 								 * If you want to override this in a child theme, then include a file
 								 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 								 */
@@ -59,13 +62,13 @@ $posts_style = get_theme_mod( 'understrap_posts_index_style' );
 						<?php get_template_part( 'loop-templates/content', 'none' ); ?>
 
 					<?php endif; ?>
-			<?php if ( 'masonry' === $posts_style ): ?></div><?php endif; ?>
+			<?php if ( 'masonry' === $posts_style ) : ?></div><?php endif; ?>
 			</main><!-- #main -->
 
 		</div><!-- #primary -->
 
 		<!-- Do the right sidebar check -->
-		<?php if ( 'right' === $sidebar_pos || 'both' === $sidebar_pos ): ?>
+		<?php if ( 'right' === $sidebar_pos || 'both' === $sidebar_pos ) : ?>
 
 			<?php get_sidebar( 'right' ); ?>
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -142,6 +142,7 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 					'choices'     => array(
 						'default'       => __( 'Default', 'understrap' ),
 						'masonry' => __( 'Masonry', 'understrap' ),
+						'grid' => __( 'Grid', 'understrap' ),
 					),
 					'priority'    => '30',
 				)

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -147,6 +147,50 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 					'priority'    => '30',
 				)
 			) );
+
+		// Columns setup for grid posts.
+		/**
+		 * Function and callback to check when grid is enabled.
+		 * @return bool
+		 */
+		function is_grid_enabled ()
+		{
+			return 'grid' == get_theme_mod( 'understrap_posts_index_style' );
+		}
+		if ( is_grid_enabled() ) {
+			// How many columns to use each grid post
+			$wp_customize->add_setting( 'understrap_grid_post_columns', array(
+				'default'    => '6',
+				'type'       => 'theme_mod',
+				'capability' => 'edit_theme_options',
+				'transport' => 'refresh',
+			) );
+
+			$wp_customize->add_control(
+				new WP_Customize_Control(
+					$wp_customize,
+					'understrap_grid_post_columns', array(
+						'label'       => __( 'Grid Post Columns', 'understrap' ),
+						'description' => __( "Choose how many columns to use in grid posts", 'understrap' ),
+						'section'     => 'understrap_theme_layout_options',
+						'settings'    => 'understrap_grid_post_columns',
+						'type'        => 'select',
+						'choices'     => array(
+							'6'       => '6',
+							'4' =>       '4',
+							'3' =>       '3',
+							'2' =>       '2',
+							'1' =>       '1',
+						),
+						'default'     =>  6,
+						'priority'    => '30',
+						'transport'   => 'refresh',
+					)
+				) );
+
+		}
+		// hook to auto-hide/show depending the understrap_posts_index_style option
+		$wp_customize->get_control( 'understrap_grid_post_columns' )->active_callback = 'is_grid_enabled';
 	}
 }
 add_action( 'customize_register', 'understrap_theme_customize_register' );

--- a/loop-templates/content-grid.php
+++ b/loop-templates/content-grid.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Partial template to display latest posts (home.php) as grid.
+ *
+ * @package understrap
+ */
+
+?>
+<a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
+	<div class="col-md-4 col-xs-12">
+
+
+		<div class="card card-inverse ">
+
+			<article <?php post_class(); ?> id="post-<?php the_ID(); ?>">
+				<?php $alt = get_post_meta( get_post_thumbnail_id( $post->ID ), '_wp_attachment_image_alt', true ); ?>
+				<img class="card-img "
+				     src="<?php echo esc_html( get_the_post_thumbnail_url( $post->ID, 'large' ) ) ?>" alt="<?php echo esc_html( $alt ); ?>">
+
+				<div class="card-img-overlay">
+
+					<header class="entry-header">
+						<h4 class="card-title"><?php the_title(); ?></h4>
+
+						<?php if ( 'post' === get_post_type() ) : ?>
+
+							<p class="entry-meta card-text">
+								<small>Posted: <?php the_date(); ?> at: <?php the_time();  ?></small>
+							</p>
+
+						<?php endif; ?>
+
+					</header>
+
+				</div>
+
+			</article>
+
+
+		</div>
+
+
+	</div>
+</a>

--- a/loop-templates/content-grid.php
+++ b/loop-templates/content-grid.php
@@ -4,10 +4,11 @@
  *
  * @package understrap
  */
-
+$col = get_theme_mod( 'understrap_grid_post_columns' );
+error_log($col);
 ?>
 <a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
-	<div class="col-md-4 col-xs-12">
+	<div class="col-md-<?php echo esc_html( $col ); ?> col-xs-12">
 
 
 		<div class="card card-inverse ">

--- a/loop-templates/content-grid.php
+++ b/loop-templates/content-grid.php
@@ -5,7 +5,6 @@
  * @package understrap
  */
 $col = get_theme_mod( 'understrap_grid_post_columns' );
-error_log($col);
 ?>
 <a href="<?php echo esc_url( get_permalink() ); ?>" rel="bookmark">
 	<div class="col-md-<?php echo esc_html( $col ); ?> col-xs-12">


### PR DESCRIPTION
As requested from @Thomas-A-Reinert here is a PR that adds the option to display latest posts (blog's main page) as grid.

Currently showing 3 posts per row without any option to modify it which should be easy to do from the customizer.

 I try to find if the customizer has the ability to conditionally show/hide secondary options. For example IF the Grid option is enabled, show the user secondary options which are only specific to the Grid display (posts per row, text- title colors, etc), until then I am leaving it as is.

Changes with this PR:

* `home.php` template changed to include the grid template
* `customizer.php` to add the new feature
* `content-grid.php` partial template that handles the rendering of individual posts

additionally changed how `get_template_part` is called.

Screenshot:

![selection_001](https://cloud.githubusercontent.com/assets/5731388/20462340/8000b546-af23-11e6-9652-916c0f25531c.jpg)
