### PR TITLE
gulp dist: skip sass directory, gulpfile.js and package.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -220,6 +220,6 @@ gulp.task('copy-assets', function() {
 // gulp dist
 // Copies the files to the /dist folder for distributon
 gulp.task('dist', function() {
-    gulp.src(['**/*','!bower_components','!bower_components/**','!node_modules','!node_modules/**','!src','!src/**','!dist','!dist/**', '*'])
+    gulp.src(['**/*','!bower_components','!bower_components/**','!gulpfile.js','!node_modules','!node_modules/**','!package.json','!sass','!sass/**','!src','!src/**','!dist','!dist/**', '*'])
     .pipe(gulp.dest('dist/'))
 });


### PR DESCRIPTION
When you consider that everything in the `dist` directory is a final product, those files/directories aren't needed. But feel free to correct me :)