### PR TITLE
fixes #171

### DIFF
--- a/js/vertical-one-page.js
+++ b/js/vertical-one-page.js
@@ -12,7 +12,7 @@
 
 	$( document ).ready(function() {
 		// smoothly scroll to an ID
-		$( 'a[href*="#"]:not([href="#"])' ).click( function ( e ) {
+		$( '#main-menu li a' ).click( function ( e ) {
 			var target;
 			// if not on root URL
 			if ( currentPage === blogPage || vars.isSingle ) {


### PR DESCRIPTION
Listen for events dispatched only from main menu li links.

It was just messing with links containing hashes `href="#collapseExample"`... It should be ok now.
