### PR TITLE
Create the source folder after npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "owl.carousel": "^2.2.0",
     "undescores-for-npm": "^1.0.0"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "scripts": {
+    "postinstall": "gulp copy-assets"
+  }
 }


### PR DESCRIPTION
Create a script in package.json which will be called after the initial installation of the node_modules. It executes gulp copy-assets and create the source-folder. 