### PR TITLE
Make Browsersync work correctly

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,7 @@ gulp.task('scss-for-prod', function() {
 
 // Run:
 // gulp sourcemaps + sass + reload(browserSync)
-// Prepare the child-theme.css for the developpment environment
+// Prepare the child-theme.css for the development environment
 gulp.task('scss-for-dev', function() {
     gulp.src('./sass/*.scss')
         .pipe(plumber())
@@ -102,7 +102,7 @@ gulp.task('watch', function () {
 
 
 // Run:
-// gulp nanocss
+// gulp cssnano
 // Minifies CSS files
 gulp.task('cssnano', ['cleancss'], function(){
   return gulp.src('./css/theme.css')

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,6 @@ var clone = require('gulp-clone');
 var merge = require('gulp-merge');
 var sourcemaps = require('gulp-sourcemaps');
 var browserSync = require('browser-sync').create();
-var reload = browserSync.reload;
 
 
 // Run:
@@ -74,7 +73,6 @@ gulp.task('scss-for-dev', function() {
         .pipe(sass())
         .pipe(sourcemaps.write(undefined, { sourceRoot: null }))
         .pipe(gulp.dest('./css'))
-        .pipe(reload({stream: true}));
 });
 
 gulp.task('watch-scss', ['browser-sync'], function () {
@@ -114,7 +112,6 @@ gulp.task('cssnano', ['cleancss'], function(){
     .pipe(cssnano({discardComments: {removeAll: true}}))
     .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('./css/'))
-    .pipe(reload({stream: true}));
 });
 
 gulp.task('cleancss', function() {


### PR DESCRIPTION
Removing reload entirely makes it possible for Browsersync to work correctly.

The error right now is that it's supposed to be injecting css into the site hot, without reloading the page for each css (.scss, .sass) file change. It does however reload on each change.

I've identified the issue to be the reload call at the end of the ['cssnano'] task. Removing it makes css inject into the site without the reload, while still making browsersync reload when other types of files change (like .php).

All other occurrences of reload seem to be obsolete as well, since it would only ever apply inside some form of 'watch' task in order to do any reloading. All other tasks with reload at the end are one-off tasks, without the need or possibility to do any reloading.

It's quite possible I've misinterpreted something though, so if anyone can check to make sure, that would be great.

P.S. the other commit fixes some typos.