### PR TITLE
Adding AJAX classes to add-to-cart buttons.

### DIFF
--- a/woocommerce/loop/add-to-cart.php
+++ b/woocommerce/loop/add-to-cart.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 global $product;
 
 echo apply_filters( 'woocommerce_loop_add_to_cart_link',
-	sprintf( '<a rel="nofollow" href="%s" data-quantity="%s" data-product_id="%s" data-product_sku="%s" class="btn btn-outline-primary btn-block">%s</a>',
+	sprintf( '<a rel="nofollow" href="%s" data-quantity="%s" data-product_id="%s" data-product_sku="%s" class="add_to_cart_button ajax_add_to_cart btn btn-outline-primary btn-block">%s</a>',
 		esc_url( $product->add_to_cart_url() ),
 		esc_attr( isset( $quantity ) ? $quantity : 1 ),
 		esc_attr( $product->id ),


### PR DESCRIPTION
Need to add in the default woocommerce ajax and add to cart classes for ajax to work. I have tested this with a default install of the latest understrap.