### PR TITLE
Typo fix. Current pages creates a ton of errors

### DIFF
--- a/woocommerce/cart/cart-empty.php
+++ b/woocommerce/cart/cart-empty.php
@@ -25,7 +25,7 @@ wc_print_notices();
 ?>
 
 <p class="cart-empty">
-	<?php esh_html_e( 'Your cart is currently empty.', 'understrap' ) ?>
+	<?php esc_html_e( 'Your cart is currently empty.', 'understrap' ) ?>
 </p>
 
 <?php do_action( 'woocommerce_cart_is_empty' ); ?>


### PR DESCRIPTION
Quick typo fix to alleviate empty-cart page errors when no items in cart.