### PR TITLE
Proper image glob patterns for imagemin task.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,14 +106,14 @@ gulp.task('watch', function () {
     gulp.watch([basePaths.dev + 'js/**/*.js','js/**/*.js','!js/theme.js','!js/theme.min.js'], ['scripts']);
 
     //Inside the watch task.
-    gulp.watch('./img', ['imagemin'])
+    gulp.watch('./img/**', ['imagemin'])
 });
 
 // Run:
 // gulp imagemin
 // Running image optimizing task
 gulp.task('imagemin', function(){
-    gulp.src('img/*')
+    gulp.src('img/**')
     .pipe(imagemin())
     .pipe(gulp.dest('img'))
 });


### PR DESCRIPTION
These globs should handle everything.

There remain questions like:

1. What if there are loads of images, I don't want it to run on all images if I just add one new one.
2. What if non-image files trigger the task.

For now, the answer to 1 is that there probably won't be that many images. I tested it out on a folder with about 3k images for country flags and it takes about 20 seconds for the lot. I then tested it on 30 images that are above 3MB each, and it takes about 2-3 seconds.
We can easily add gulp-changed if it turns out performance is an issue here.

The answer to 2 is that it ignores files it doesn't know how to handle, so that's also fine.