### PR TITLE
Fix deprecated product accessor for WC 3.0

### DIFF
--- a/woocommerce/loop/add-to-cart.php
+++ b/woocommerce/loop/add-to-cart.php
@@ -26,7 +26,7 @@ echo apply_filters( 'woocommerce_loop_add_to_cart_link',
 	sprintf( '<a rel="nofollow" href="%s" data-quantity="%s" data-product_id="%s" data-product_sku="%s" class="add_to_cart_button ajax_add_to_cart btn btn-outline-primary btn-block">%s</a>',
 		esc_url( $product->add_to_cart_url() ),
 		esc_attr( isset( $quantity ) ? $quantity : 1 ),
-		esc_attr( $product->id ),
+		esc_attr( $product->get_id() ),
 		esc_attr( $product->get_sku() ),
 		esc_html( $product->add_to_cart_text() )
 	),


### PR DESCRIPTION
Uses new 3.0 CRUD method to eliminate current PHP Notice from wc_doing_it_wrong.

Ref: 
https://github.com/woocommerce/woocommerce/blob/master/templates/loop/add-to-cart.php
