### PR TITLE
Specify correct post templates for jetpack infinite scroll.

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -37,9 +37,9 @@ function components_infinite_scroll_render() {
 	while ( have_posts() ) {
 		the_post();
 		if ( is_search() ) :
-			get_template_part( 'components/post/content', 'search' );
+			get_template_part( 'loop-templates/content', 'search' );
 		else :
-			get_template_part( 'components/post/content', get_post_format() );
+			get_template_part( 'loop-templates/content', get_post_format() );
 		endif;
 	}
 }


### PR DESCRIPTION
Both button and scroll methods work now. Keep in mind the settings you use under Settings > Reading govern the number of posts loaded via button and 7 posts for scroll method.