### PR TITLE
Fix wrong escaping functions

### DIFF
--- a/404.php
+++ b/404.php
@@ -14,7 +14,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
 <div class="wrapper" id="404-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content" tabindex="-1">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content" tabindex="-1">
 
 		<div class="row">
 

--- a/archive.php
+++ b/archive.php
@@ -17,7 +17,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
 <div class="wrapper" id="archive-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content" tabindex="-1">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content" tabindex="-1">
 
 		<div class="row">
 

--- a/author.php
+++ b/author.php
@@ -41,7 +41,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 						<?php if ( ! empty( $curauth->user_url ) ) : ?>
 							<dt><?php esc_html_e( 'Website', 'understrap' ); ?></dt>
 							<dd>
-								<a href="<?php echo esc_attr( $curauth->user_url ); ?>"><?php echo esc_html( $curauth->user_url ); ?></a>
+								<a href="<?php echo esc_url( $curauth->user_url ); ?>"><?php echo esc_html( $curauth->user_url ); ?></a>
 							</dd>
 						<?php endif; ?>
 

--- a/author.php
+++ b/author.php
@@ -15,7 +15,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
 <div class="wrapper" id="author-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content" tabindex="-1">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content" tabindex="-1">
 
 		<div class="row">
 
@@ -41,7 +41,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 						<?php if ( ! empty( $curauth->user_url ) ) : ?>
 							<dt><?php esc_html_e( 'Website', 'understrap' ); ?></dt>
 							<dd>
-								<a href="<?php echo esc_html( $curauth->user_url ); ?>"><?php echo esc_html( $curauth->user_url ); ?></a>
+								<a href="<?php echo esc_attr( $curauth->user_url ); ?>"><?php echo esc_html( $curauth->user_url ); ?></a>
 							</dd>
 						<?php endif; ?>
 

--- a/footer.php
+++ b/footer.php
@@ -15,7 +15,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 <div class="wrapper" id="wrapper-footer">
 
-	<div class="<?php echo esc_html( $container ); ?>">
+	<div class="<?php echo esc_attr( $container ); ?>">
 
 		<div class="row">
 

--- a/inc/bootstrap-wp-navwalker.php
+++ b/inc/bootstrap-wp-navwalker.php
@@ -64,9 +64,9 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		} else if ( strcasecmp( $item->title, 'divider' ) == 0 && $depth === 1 ) {
 			$output .= $indent . '<li class="divider" role="presentation">';
 		} else if ( strcasecmp( $item->attr_title, 'dropdown-header' ) == 0 && $depth === 1 ) {
-			$output .= $indent . '<li class="dropdown-header" role="presentation">' . esc_attr( $item->title );
+			$output .= $indent . '<li class="dropdown-header" role="presentation">' . esc_html( $item->title );
 		} else if ( strcasecmp( $item->attr_title, 'disabled' ) == 0 ) {
-			$output .= $indent . '<li class="disabled" role="presentation"><a href="#">' . esc_attr( $item->title ) . '</a>';
+			$output .= $indent . '<li class="disabled" role="presentation"><a href="#">' . esc_html( $item->title ) . '</a>';
 		} else {
 			$class_names = $value = '';
 			$classes     = empty( $item->classes ) ? array() : (array) $item->classes;

--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
 <div class="wrapper" id="wrapper-index">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content" tabindex="-1">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content" tabindex="-1">
 
 		<div class="row">
 

--- a/page-templates/both-sidebarspage.php
+++ b/page-templates/both-sidebarspage.php
@@ -13,7 +13,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 <div class="wrapper" id="page-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content">
 
 		<div class="row">
 

--- a/page-templates/fullwidthpage.php
+++ b/page-templates/fullwidthpage.php
@@ -13,7 +13,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 <div class="wrapper" id="full-width-page-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content">
 
 		<div class="row">
 

--- a/page-templates/left-sidebarpage.php
+++ b/page-templates/left-sidebarpage.php
@@ -13,7 +13,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 <div class="wrapper" id="page-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content">
 
 		<div class="row">
 

--- a/page-templates/right-sidebarpage.php
+++ b/page-templates/right-sidebarpage.php
@@ -13,7 +13,7 @@ $container = get_theme_mod( 'understrap_container_type' );
 
 <div class="wrapper" id="page-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content">
 
 		<div class="row">
 

--- a/page.php
+++ b/page.php
@@ -19,7 +19,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
 <div class="wrapper" id="page-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content" tabindex="-1">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content" tabindex="-1">
 
 		<div class="row">
 

--- a/search.php
+++ b/search.php
@@ -13,7 +13,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
 <div class="wrapper" id="search-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content" tabindex="-1">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content" tabindex="-1">
 
 		<div class="row">
 

--- a/sidebar-footerfull.php
+++ b/sidebar-footerfull.php
@@ -15,7 +15,7 @@ $container   = get_theme_mod( 'understrap_container_type' );
 
 	<div class="wrapper" id="wrapper-footer-full">
 
-		<div class="<?php echo esc_html( $container ); ?>" id="footer-full-content" tabindex="-1">
+		<div class="<?php echo esc_attr( $container ); ?>" id="footer-full-content" tabindex="-1">
 
 			<div class="row">
 

--- a/sidebar-statichero.php
+++ b/sidebar-statichero.php
@@ -15,7 +15,7 @@ $container   = get_theme_mod( 'understrap_container_type' );
 
 	<div class="wrapper" id="wrapper-static-hero">
 
-			<div class="<?php echo esc_html( $container ); ?>" id="wrapper-static-content" tabindex="-1">
+			<div class="<?php echo esc_attr( $container ); ?>" id="wrapper-static-content" tabindex="-1">
 
 				<div class="row">
 

--- a/single.php
+++ b/single.php
@@ -12,7 +12,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
 <div class="wrapper" id="single-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content" tabindex="-1">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content" tabindex="-1">
 
 		<div class="row">
 

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -19,7 +19,7 @@ $sidebar_pos = get_theme_mod( 'understrap_sidebar_position' );
 
 <div class="wrapper" id="woocommerce-wrapper">
 
-	<div class="<?php echo esc_html( $container ); ?>" id="content" tabindex="-1">
+	<div class="<?php echo esc_attr( $container ); ?>" id="content" tabindex="-1">
 
 		<div class="row">
 

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -56,7 +56,7 @@ do_action( 'woocommerce_before_cart' ); ?>
 								echo apply_filters( 'woocommerce_cart_item_remove_link', sprintf(
 									'<a href="%s" class="remove" aria-label="%s" data-product_id="%s" data-product_sku="%s">&times;</a>',
 									esc_url( WC()->cart->get_remove_url( $cart_item_key ) ),
-									__( 'Remove this item', 'understrap' ),
+									esc_attr__( 'Remove this item', 'understrap' ),
 									esc_attr( $product_id ),
 									esc_attr( $_product->get_sku() )
 								), $cart_item_key );

--- a/woocommerce/cart/mini-cart.php
+++ b/woocommerce/cart/mini-cart.php
@@ -46,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						echo apply_filters( 'woocommerce_cart_item_remove_link', sprintf(
 							'<a href="%s" class="remove" title="%s" data-product_id="%s" data-product_sku="%s">&times;</a>',
 							esc_url( WC()->cart->get_remove_url( $cart_item_key ) ),
-							__( 'Remove this item', 'understrap' ),
+							esc_attr__( 'Remove this item', 'understrap' ),
 							esc_attr( $product_id ),
 							esc_attr( $_product->get_sku() )
 						), $cart_item_key );


### PR DESCRIPTION
When escaping HTML attributes we should use `esc_attr()`, not `esc_html()`.

This pull request replaces the wrong functions.