### PR TITLE
Fix package name typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "merge2": "^1.0.3",
     "run-sequence": "^1.2.2",
     "gulp-sequence": "^0.4.6",
-    "undescores-for-npm": "^1.0.0"
+    "underscores-for-npm": "^1.0.0"
   }
 }


### PR DESCRIPTION
"underscores-for-npm" was missing an r