### PR TITLE
remove_action in inc/security.php

### DIFF
--- a/inc/security.php
+++ b/inc/security.php
@@ -25,8 +25,8 @@ remove_action( 'wp_head', 'wlwmanifest_link' );
 remove_action( 'wp_head', 'index_rel_link' );
 remove_action( 'wp_head', 'feed_links', 2 );
 remove_action( 'wp_head', 'feed_links_extra', 3 );
-remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0 );
-remove_action( 'wp_head', 'wp_shortlink_wp_head', 10, 0 );
+remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10);
+remove_action( 'wp_head', 'wp_shortlink_wp_head', 10);
 
 /**
  * Show less info to users on failed login for security.


### PR DESCRIPTION
This doc shows that remove_action can take only 3 params
https://codex.wordpress.org/Function_Reference/remove_action