### PR TITLE
Variable product ajax_add_to_cart fix.

### DIFF
--- a/woocommerce/loop/add-to-cart.php
+++ b/woocommerce/loop/add-to-cart.php
@@ -19,15 +19,16 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
 global $product;
-
 echo apply_filters( 'woocommerce_loop_add_to_cart_link',
-	sprintf( '<a rel="nofollow" href="%s" data-quantity="%s" data-product_id="%s" data-product_sku="%s" class="add_to_cart_button ajax_add_to_cart btn btn-outline-primary btn-block">%s</a>',
+	sprintf( '<div class="add-to-cart-container"><a href="%s" rel="nofollow" data-product_id="%s" data-product_sku="%s" data-quantity="%s" class="%s product_type_%s single_add_to_cart_button btn btn-outline-primary btn-block %s"> %s</a></div>',
 		esc_url( $product->add_to_cart_url() ),
-		esc_attr( isset( $quantity ) ? $quantity : 1 ),
 		esc_attr( $product->get_id() ),
 		esc_attr( $product->get_sku() ),
+		esc_attr( isset( $quantity ) ? $quantity : 1 ),
+	$product->is_purchasable() && $product->is_in_stock() ? 'add_to_cart_button' : '',
+		esc_attr( $product->get_type() ),
+	$product->get_type() == 'simple' ? 'ajax_add_to_cart' : '',
 		esc_html( $product->add_to_cart_text() )
 	),
 	$product );


### PR DESCRIPTION
Ensure simple products still use the class ajax_add_to_cart but not have them interfere with Variable products. Fixes the issue where hitting "Select options" on a variable product from the archive-product.php template adds them straight to cart.