### PR TITLE
Making the class pluggable

### DIFF
--- a/inc/bootstrap-wp-navwalker.php
+++ b/inc/bootstrap-wp-navwalker.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if (! class_exists ( 'WP_Bootstrap_Navwalker' )) :
+
 /**
  * Class WP_Bootstrap_Navwalker
  * GitHub URI: https://github.com/twittem/wp-bootstrap-navwalker
@@ -210,3 +212,5 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		}
 	}
 }
+
+endif; /* End if class exists */


### PR DESCRIPTION
As it would not affect any other users of the parent/child theme, placing a request that the class first checks if the class exits,  so it could be overridden in a child theme if needed