### PR TITLE
removed required file code

### DIFF
--- a/inc/setup.php
+++ b/inc/setup.php
@@ -5,7 +5,6 @@
  * @package understrap
  */
 
-require get_template_directory() . '/inc/theme-settings.php';
 
 // Set the content width based on the theme's design and stylesheet.
 if ( ! isset( $content_width ) ) {


### PR DESCRIPTION
Its a bad idea to require file anywhere other than functions.php, so moving following line of code to functions.php
require get_template_directory() . '/inc/theme-settings.php';

bugfix:
https://github.com/holger1411/understrap/issues/472