### PR TITLE
Update customizer.php

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -57,7 +57,8 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 		$wp_customize->add_setting( 'understrap_container_type', array(
 			'default'           => 'container',
 			'type'              => 'theme_mod',
-			'sanitize_callback' => 'understrap_theme_slug_sanitize_select',
+			//'sanitize_callback' => 'understrap_theme_slug_sanitize_select',
+			'sanitize_callback' => 'sanitize_text_field',
 			'capability'        => 'edit_theme_options',
 		) );
 


### PR DESCRIPTION
Currently in understrap Version: 0.6.12 in the Theme Layout Settings the container type isn't setting. The above change sets it back to its default so it will set the whether or not the user wants a fixed container or full width container layout