### PR TITLE
Woocommerce Product Slider Gallery Fix

### DIFF
--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -15,9 +15,7 @@ if ( ! function_exists( 'understrap_woocommerce_support' ) ) {
 		// Add New Woocommerce 3.0.0 Product Gallery support
 		add_theme_support( 'wc-product-gallery-lightbox' );
 		add_theme_support( 'wc-product-gallery-zoom' );
-
-		// Gallery slider needs Flexslider - https://woocommerce.com/flexslider/
-		//add_theme_support( 'wc-product-gallery-slider' );
+		add_theme_support( 'wc-product-gallery-slider' );
 
 		// hook in and customizer form fields.
 		add_filter( 'woocommerce_form_field_args', 'understrap_wc_form_field_args', 10, 3 );

--- a/sass/understrap/understrap.scss
+++ b/sass/understrap/understrap.scss
@@ -43,6 +43,11 @@
 // Post design
 .entry-footer span { padding-right: 10px; }
 
+//Woocommerce product gallery slider width fix
+figure.woocommerce-product-gallery__wrapper { 
+  max-width: inherit !important; 
+}
+
 // Limit featured image size to 100%
 img.wp-post-image,
 article img,


### PR DESCRIPTION
Might need `gulp cleancss` and then `gulp-styles` for it to take effect if viewing for first time.