### PR TITLE
Gulp improvements and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To work and compile your Sass files on the fly start:
 Or, to run with Browser-Sync:
 
 - First change the browser-sync options to reflect your environment in the file `/gulpconfig.json` in the beginning of the file:
-```json
+```javascript
 {
     "browserSyncOptions" : {
         "proxy": "localhost/theme_test/", // <----- CHANGE HERE

--- a/README.md
+++ b/README.md
@@ -95,11 +95,14 @@ To work and compile your Sass files on the fly start:
 
 Or, to run with Browser-Sync:
 
-- First change the browser-sync options to reflect your environment in the file `/gulpfile.js` in the beginning of the file:
-```javascript
-var browserSyncOptions = {
-    proxy: "localhost/theme_test/", // <----- CHANGE HERE
-    notify: false
+- First change the browser-sync options to reflect your environment in the file `/gulpconfig.json` in the beginning of the file:
+```json
+{
+    "browserSyncOptions" : {
+        "proxy": "localhost/theme_test/", // <----- CHANGE HERE
+        "notify": false
+    },
+    ...
 };
 ```
 - then run: `$ gulp watch-bs`

--- a/gulpconfig.json
+++ b/gulpconfig.json
@@ -11,6 +11,8 @@
   "paths" : {
     "js": "./js",
     "css": "./css",
+    "img": "./img",
+		"imgsrc": "./src/img",
     "sass": "./sass",
     "node": "./node_modules/",
     "bower": "./bower_components/",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -256,7 +256,7 @@ gulp.task('clean-vendor-assets', function () {
 // gulp dist
 // Copies the files to the /dist folder for distribution as simple theme
 gulp.task('dist', ['clean-dist'], function() {
-  return gulp.src(['**/*', '!'+paths.bower, '!'+paths.bower+'**', '!'+paths.node, '!'+paths.node+'**', '!'+paths.dev, '!'+paths.dev+'/**', '!'+paths.dist, '!'+paths.dist+'/**', '!'+paths.distprod, '!'+paths.distprod+'/**', '!'+paths.sass, '!'+paths.sass+'/**', '!readme.txt', '!readme.md', '!package.json', '!gulpfile.js', '!CHANGELOG.md', '!.travis.yml', '!jshintignore',  '!codesniffer.ruleset.xml',  '*'])
+  return gulp.src(['**/*', '!'+paths.bower, '!'+paths.bower+'/**', '!'+paths.node, '!'+paths.node+'/**', '!'+paths.dev, '!'+paths.dev+'/**', '!'+paths.dist, '!'+paths.dist+'/**', '!'+paths.distprod, '!'+paths.distprod+'/**', '!'+paths.sass, '!'+paths.sass+'/**', '!readme.txt', '!readme.md', '!package.json', '!package-lock.json', '!gulpfile.js', '!gulpconfig.json', '!CHANGELOG.md', '!.travis.yml', '!jshintignore',  '!codesniffer.ruleset.xml',  '*'], {'buffer': false})
   .pipe(replace('/js/jquery.slim.min.js', '/js'+paths.vendor+'/jquery.slim.min.js', {'skipBinary': true}))
   .pipe(replace('/js/popper.min.js', '/js'+paths.vendor+'/popper.min.js', {'skipBinary': true}))
   .pipe(replace('/js/skip-link-focus-fix.js', '/js'+paths.vendor+'/skip-link-focus-fix.js', {'skipBinary': true}))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -257,9 +257,9 @@ gulp.task('clean-vendor-assets', function () {
 // Copies the files to the /dist folder for distribution as simple theme
 gulp.task('dist', ['clean-dist'], function() {
   return gulp.src(['**/*', '!'+paths.bower, '!'+paths.bower+'**', '!'+paths.node, '!'+paths.node+'**', '!'+paths.dev, '!'+paths.dev+'/**', '!'+paths.dist, '!'+paths.dist+'/**', '!'+paths.distprod, '!'+paths.distprod+'/**', '!'+paths.sass, '!'+paths.sass+'/**', '!readme.txt', '!readme.md', '!package.json', '!gulpfile.js', '!CHANGELOG.md', '!.travis.yml', '!jshintignore',  '!codesniffer.ruleset.xml',  '*'])
-    .pipe(replace('/js/jquery.slim.min.js', '/js'+paths.vendor+'/jquery.slim.min.js'))
-    .pipe(replace('/js/popper.min.js', '/js'+paths.vendor+'/popper.min.js'))
-    .pipe(replace('/js/skip-link-focus-fix.js', '/js'+paths.vendor+'/skip-link-focus-fix.js'))
+  .pipe(replace('/js/jquery.slim.min.js', '/js'+paths.vendor+'/jquery.slim.min.js', {'skipBinary': true}))
+  .pipe(replace('/js/popper.min.js', '/js'+paths.vendor+'/popper.min.js', {'skipBinary': true}))
+  .pipe(replace('/js/skip-link-focus-fix.js', '/js'+paths.vendor+'/skip-link-focus-fix.js', {'skipBinary': true}))
     .pipe(gulp.dest(paths.dist));
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,16 +101,25 @@ gulp.task('watch', function () {
     gulp.watch([paths.dev + '/js/**/*.js','js/**/*.js','!js/theme.js','!js/theme.min.js'], ['scripts']);
 
     //Inside the watch task.
-    gulp.watch('./img/**', ['imagemin'])
+    gulp.watch(paths.imgsrc + '/**', ['imagemin-watch']);
+});
+
+/**
+ * Ensures the 'imagemin' task is complete before reloading browsers
+ * @verbose
+ */
+gulp.task('imagemin-watch', ['imagemin'], function(done) {
+  browserSync.reload();
+  done();
 });
 
 // Run:
 // gulp imagemin
 // Running image optimizing task
 gulp.task('imagemin', function(){
-    gulp.src('img/src/**')
+    gulp.src(paths.imgsrc + '/**')
     .pipe(imagemin())
-    .pipe(gulp.dest('img'))
+    .pipe(gulp.dest(paths.img))
 });
 
 


### PR DESCRIPTION
I found that large image files were breaking on gulp copy so this adds {'buffer':false} to the gulp.src and {'skipBinary':true} to the gulp-replace to make sure they copied properly. 

While I was at it I have included a fix for issue #414 (and a couple others) where browserSync gets stuck looping on imagemin. _In my own build env, I have further isolated the css so that it can inject into the stream without a browser reload. If you want me to include that, let me know._ 

Finally, there is an update to the README.md for moving the browserSyncOptions into the guilpconfig file. 