### PR TITLE
Removed "false" to avoid empty "media"-value

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -12,7 +12,7 @@ if ( ! function_exists( 'understrap_scripts' ) ) {
 	function understrap_scripts() {
 		// Get the theme data.
 		$the_theme = wp_get_theme();
-		wp_enqueue_style( 'understrap-styles', get_stylesheet_directory_uri() . '/css/theme.min.css', array(), $the_theme->get( 'Version' ), false );
+		wp_enqueue_style( 'understrap-styles', get_stylesheet_directory_uri() . '/css/theme.min.css', array(), $the_theme->get( 'Version' ) );
 		wp_enqueue_script( 'jquery');
 		wp_enqueue_script( 'popper-scripts', get_template_directory_uri() . '/js/popper.min.js', array(), true);
 		wp_enqueue_script( 'understrap-scripts', get_template_directory_uri() . '/js/theme.min.js', array(), $the_theme->get( 'Version' ), true );


### PR DESCRIPTION
Removed "false" to avoid empty "media"-value which invalidates HTML. Renders as media="all" if omitted.

See: https://developer.wordpress.org/reference/functions/wp_enqueue_style/ for how to correctly enqueue styles.