### PR TITLE
Rename woocommerce related functions 

### DIFF
--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -8,6 +8,22 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+if ( ! function_exists( 'understrap_quantity_input_classes' ) ) {
+	/**
+	 * Add Bootstrap class to quantity input field.
+	 *
+	 * @deprecated 1.2.0 Use understrap_wc_quantity_input_classes()
+	 * @see understrap_wc_quantity_input_classes()
+	 *
+	 * @param array $classes Array of quantity input classes.
+	 * @return array
+	 */
+	function understrap_quantity_input_classes( $classes ) {
+		_deprecated_function( __FUNCTION__, '1.2.0', 'understrap_wc_quantity_input_classes' );
+		return understrap_wc_quantity_input_classes( $classes );
+	}
+}
+
 if ( ! function_exists( 'understrap_theme_slug_sanitize_select' ) ) {
 	/**
 	 * Sanitize select.

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -24,14 +24,14 @@ if ( ! function_exists( 'understrap_woocommerce_support' ) ) {
 		// Add Bootstrap classes to form fields.
 		add_filter( 'woocommerce_form_field_args', 'understrap_wc_form_field_args', 10, 3 );
 		add_filter( 'woocommerce_form_field_radio', 'understrap_wc_form_field_radio', 10, 4 );
-		add_filter( 'woocommerce_quantity_input_classes', 'understrap_quantity_input_classes' );
-		add_filter( 'woocommerce_loop_add_to_cart_args', 'understrap_loop_add_to_cart_args' );
+		add_filter( 'woocommerce_quantity_input_classes', 'understrap_wc_quantity_input_classes' );
+		add_filter( 'woocommerce_loop_add_to_cart_args', 'understrap_wc_loop_add_to_cart_args' );
 
 		// Wrap the add-to-cart link in `div.add-to-cart-container`.
-		add_filter( 'woocommerce_loop_add_to_cart_link', 'understrap_loop_add_to_cart_link' );
+		add_filter( 'woocommerce_loop_add_to_cart_link', 'understrap_wc_loop_add_to_cart_link' );
 
 		// Add Bootstrap classes to account navigation.
-		add_filter( 'woocommerce_account_menu_item_classes', 'understrap_account_menu_item_classes' );
+		add_filter( 'woocommerce_account_menu_item_classes', 'understrap_wc_account_menu_item_classes' );
 	}
 }
 
@@ -46,6 +46,8 @@ add_action( 'woocommerce_after_main_content', 'understrap_woocommerce_wrapper_en
 if ( ! function_exists( 'understrap_woocommerce_wrapper_start' ) ) {
 	/**
 	 * Display the theme specific start of the page wrapper.
+	 *
+	 * @since 0.8.2
 	 */
 	function understrap_woocommerce_wrapper_start() {
 		$container = get_theme_mod( 'understrap_container_type' );
@@ -64,6 +66,8 @@ if ( ! function_exists( 'understrap_woocommerce_wrapper_start' ) ) {
 if ( ! function_exists( 'understrap_woocommerce_wrapper_end' ) ) {
 	/**
 	 * Display the theme specific end of the page wrapper.
+	 *
+	 * @since 0.8.2
 	 */
 	function understrap_woocommerce_wrapper_end() {
 		echo '</main>';
@@ -252,39 +256,45 @@ if ( ! is_admin() && ! function_exists( 'wc_review_ratings_enabled' ) ) {
 	}
 }
 
-if ( ! function_exists( 'understrap_quantity_input_classes' ) ) {
+if ( ! function_exists( 'understrap_wc_quantity_input_classes' ) ) {
 	/**
 	 * Add Bootstrap class to quantity input field.
+	 *
+	 * @since 1.2.0
 	 *
 	 * @param array $classes Array of quantity input classes.
 	 * @return array
 	 */
-	function understrap_quantity_input_classes( $classes ) {
+	function understrap_wc_quantity_input_classes( $classes ) {
 		$classes[] = 'form-control';
 		return $classes;
 	}
 }
 
-if ( ! function_exists( 'understrap_loop_add_to_cart_link' ) ) {
+if ( ! function_exists( 'understrap_wc_loop_add_to_cart_link' ) ) {
 	/**
 	 * Wrap add to cart link in container.
+	 *
+	 * @since 1.2.0
 	 *
 	 * @param string $html Add to cart link HTML.
 	 * @return string Add to cart link HTML.
 	 */
-	function understrap_loop_add_to_cart_link( $html ) {
+	function understrap_wc_loop_add_to_cart_link( $html ) {
 		return '<div class="add-to-cart-container">' . $html . '</div>';
 	}
 }
 
-if ( ! function_exists( 'understrap_loop_add_to_cart_args' ) ) {
+if ( ! function_exists( 'understrap_wc_loop_add_to_cart_args' ) ) {
 	/**
 	 * Add Bootstrap button classes to add to cart link.
+	 *
+	 * @since 1.2.0
 	 *
 	 * @param array<string,mixed> $args Array of add to cart link arguments.
 	 * @return array<string,mixed> Array of add to cart link arguments.
 	 */
-	function understrap_loop_add_to_cart_args( $args ) {
+	function understrap_wc_loop_add_to_cart_args( $args ) {
 		if ( isset( $args['class'] ) && ! empty( $args['class'] ) ) {
 			if ( ! is_string( $args['class'] ) ) {
 				return $args;
@@ -310,14 +320,16 @@ if ( ! function_exists( 'understrap_loop_add_to_cart_args' ) ) {
 	}
 }
 
-if ( ! function_exists( 'understrap_account_menu_item_classes' ) ) {
+if ( ! function_exists( 'understrap_wc_account_menu_item_classes' ) ) {
 	/**
 	 * Add Bootstrap classes to the
+	 *
+	 * @since 1.2.0
 	 *
 	 * @param string[] $classes Array of classes added to the account menu items.
 	 * @return string[] Array of classes added to the account menu items.
 	 */
-	function understrap_account_menu_item_classes( $classes ) {
+	function understrap_wc_account_menu_item_classes( $classes ) {
 		$classes[] = 'list-group-item';
 		$classes[] = 'list-group-item-action';
 		if ( in_array( 'is-active', $classes, true ) ) {

--- a/inc/woocommerce.php
+++ b/inc/woocommerce.php
@@ -260,7 +260,7 @@ if ( ! function_exists( 'understrap_wc_quantity_input_classes' ) ) {
 	/**
 	 * Add Bootstrap class to quantity input field.
 	 *
-	 * @since 1.2.0
+	 * @since 1.2.0 Renamed from understrap_quantity_input_classes()
 	 *
 	 * @param array $classes Array of quantity input classes.
 	 * @return array

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -146,11 +146,6 @@ parameters:
 			path: inc/woocommerce.php
 
 		-
-			message: "#^Parameter \\#2 \\$callback of function add_filter expects callable\\(\\)\\: mixed, 'understrap_quantity…' given\\.$#"
-			count: 1
-			path: inc/woocommerce.php
-
-		-
 			message: "#^Part \\$args\\['label'\\] \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
 			count: 1
 			path: inc/woocommerce.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,12 +136,17 @@ parameters:
 			path: inc/woocommerce.php
 
 		-
-			message: "#^Function understrap_quantity_input_classes\\(\\) has parameter \\$classes with no value type specified in iterable type array\\.$#"
+			message: "#^Function understrap_wc_quantity_input_classes\\(\\) has parameter \\$classes with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: inc/woocommerce.php
 
 		-
-			message: "#^Function understrap_quantity_input_classes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: "#^Function understrap_wc_quantity_input_classes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: inc/woocommerce.php
+
+		-
+			message: "#^Parameter \\#2 \\$callback of function add_filter expects callable\\(\\)\\: mixed, 'understrap_quantity…' given\\.$#"
 			count: 1
 			path: inc/woocommerce.php
 


### PR DESCRIPTION
## Description
This PR renames some WooCommerce related functions:
* `understrap_quantity_input_classes` -> `understrap_wc_quantity_input_classes`
* `understrap_loop_add_to_cart_args` -> `understrap_wc_loop_add_to_cart_args`
* `understrap_loop_add_to_cart_link` -> `understrap_wc_loop_add_to_cart_link`
* `understrap_account_menu_item_classes` -> `understrap_wc_account_menu_item_classes`

## Motivation and Context
Make it self-explanatory that these functions are related to WooCommerce.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] `composer cs:check` has passed locally.
- [x] `composer lint:php` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
* `understrap_quantity_input_classes()` is properly deprecated. The other 3 functions have not been released yet and therefor need no deprecation.
* This PR assumes to get merged in v1.2.0. If it is merged in another version, the version numbers in the `_deprecated_function()` calls and the functions comments need to be adjusted accordingly.
