### PR TITLE
Fixed 'Featured Image' block not working

### DIFF
--- a/inc/setup.php
+++ b/inc/setup.php
@@ -70,7 +70,7 @@ if ( ! function_exists( 'understrap_setup' ) ) {
 		/*
 		 * Adding Thumbnail basic support
 		 */
-		add_theme_support( 'post-thumbnails', array() );
+		add_theme_support( 'post-thumbnails' );
 
 		/*
 		 * Adding support for Widget edit icons in customizer


### PR DESCRIPTION
Default empty array for post-thumbnails was causing it to not display.

<!--- Provide a general summary of your changes in the Title above -->

## Description
**array()** was present in the add_theme_support function for post-thumbnails causing all featured image blocks to break unless individually specified.

## Motivation and Context
Fixes a core feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (a code change that neither fixes a bug nor adds a feature)
- [ ] Styling (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Development (changes that affect the build system or external dependencies)
- [ ] Documentation (changes that affect existing inline documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [ ] `composer phpcs` has passed locally.
- [ ] `composer php-lint` has passed locally.
- [ ] `composer phpmd` has passed locally.
- [ ] `composer phpstan` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
