### PR TITLE
Improve readability and escape translations

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -46,9 +46,8 @@ if ( ! function_exists( 'understrap_customize_partial_custom_logo' ) ) {
 	function understrap_customize_partial_custom_logo() {
 		if ( has_custom_logo() ) {
 			return get_custom_logo();
-		} else {
-			return get_bloginfo( 'name' );
 		}
+		return get_bloginfo( 'name' );
 	}
 }
 
@@ -115,7 +114,7 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 				'understrap_container_type',
 				array(
 					'label'       => __( 'Container Width', 'understrap' ),
-					'description' => __( 'Choose between Bootstrap\'s container and container-fluid', 'understrap' ),
+					'description' => __( "Choose between Bootstrap's container and container-fluid", 'understrap' ),
 					'section'     => 'understrap_theme_layout_options',
 					'type'        => 'select',
 					'choices'     => array(
@@ -175,7 +174,7 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 				array(
 					'label'       => __( 'Sidebar Positioning', 'understrap' ),
 					'description' => __(
-						'Set sidebar\'s default position. Can either be: right, left, both or none. Note: this can be overridden on individual pages.',
+						"Set sidebar's default position. Can either be: right, left, both or none. Note: this can be overridden on individual pages.",
 						'understrap'
 					),
 					'section'     => 'understrap_theme_layout_options',
@@ -207,7 +206,7 @@ if ( ! function_exists( 'understrap_theme_customize_register' ) ) {
 				'understrap_site_info_override',
 				array(
 					'label'       => __( 'Footer Site Info', 'understrap' ),
-					'description' => __( 'Override Understrap\'s site info located at the footer of the page.', 'understrap' ),
+					'description' => __( "Override Understrap's site info located at the footer of the page.", 'understrap' ),
 					'section'     => 'understrap_theme_layout_options',
 					'type'        => 'textarea',
 					'priority'    => 20,

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -206,7 +206,7 @@ if ( ! function_exists( 'understrap_body_attributes' ) ) {
 		 * @param array $atts An associative array of attributes.
 		 */
 		$atts = array_unique( apply_filters( 'understrap_body_attributes', $atts = array() ) );
-		if ( 0 === count( $atts ) ) {
+		if ( array() === $atts ) {
 			return;
 		}
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -285,33 +285,30 @@ if ( ! function_exists( 'understrap_edit_post_link' ) ) {
 if ( ! function_exists( 'understrap_post_nav' ) ) {
 	/**
 	 * Displays the navigation to the next/previous post when applicable.
-	 *
-	 * @global WP_Post|null $post The current post.
 	 */
 	function understrap_post_nav() {
-		global $post;
-		if ( ! $post ) {
+		$previous_post_link = get_previous_post_link(
+			'<span class="nav-previous">%link</span>',
+			_x( '<i class="fa fa-angle-left"></i>&nbsp;%title', 'Previous post link', 'understrap' )
+		);
+
+		$next_post_link = get_next_post_link(
+			'<span class="nav-next">%link</span>',
+			_x( '%title&nbsp;<i class="fa fa-angle-right"></i>', 'Next post link', 'understrap' )
+		);
+
+		// Don't print empty markup if there's nowhere to navigate.
+		if ( '' === $previous_post_link && '' === $next_post_link ) {
 			return;
 		}
 
-		// Don't print empty markup if there's nowhere to navigate.
-		$previous = ( is_attachment() ) ? get_post( $post->post_parent ) : get_adjacent_post( false, '', true );
-		$next     = get_adjacent_post( false, '', false );
-		if ( ! $next && ! $previous ) {
-			return;
-		}
 		?>
 		<nav class="container navigation post-navigation">
 			<h2 class="screen-reader-text"><?php esc_html_e( 'Post navigation', 'understrap' ); ?></h2>
 			<div class="d-flex nav-links justify-content-between">
 				<?php
-				if ( get_previous_post_link() ) {
-					previous_post_link( '<span class="nav-previous">%link</span>', _x( '<i class="fa fa-angle-left"></i>&nbsp;%title', 'Previous post link', 'understrap' ) );
-				}
-
-				if ( get_next_post_link() ) {
-					next_post_link( '<span class="nav-next">%link</span>', _x( '%title&nbsp;<i class="fa fa-angle-right"></i>', 'Next post link', 'understrap' ) );
-				}
+				echo wp_kses_post( $previous_post_link );
+				echo wp_kses_post( $next_post_link );
 				?>
 			</div><!-- .nav-links -->
 		</nav><!-- .post-navigation -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -250,11 +250,11 @@ if ( ! function_exists( 'understrap_comment_navigation' ) ) {
 			);
 
 			previous_comments_link(
-				esc_html( __( '&larr; Older Comments', 'understrap' ) )
+				esc_html__( '&larr; Older Comments', 'understrap' )
 			);
 
 			next_comments_link(
-				esc_html( __( 'Newer Comments &rarr;', 'understrap' ) )
+				esc_html__( 'Newer Comments &rarr;', 'understrap' )
 			);
 			?>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR
- improves readability.
- escapes the post nav links using `wp_kses_post()`.
- escapes the comments nav links labels using `esc_html()`.

## Motivation and Context
More readable code is easier to understand, maintain, and debug.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (a code change that neither fixes a bug nor adds a feature)
- [x] Styling (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Development (changes that affect the build system or external dependencies)
- [x] Documentation (changes that affect existing inline documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer phpcs` has passed locally.
- [x] `composer php-lint` has passed locally.
- [x] `composer phpmd` has passed locally.
- [x] `composer phpstan` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
