### PR TITLE
Improve styles to adjust offcanvas margin with admin bar

### DIFF
--- a/inc/enqueue.php
+++ b/inc/enqueue.php
@@ -49,27 +49,43 @@ add_action( 'wp_enqueue_scripts', 'understrap_scripts' );
 
 if ( ! function_exists( 'understrap_offcanvas_admin_bar_inline_styles' ) ) {
 	/**
-	 * Add inline styles for the offcanvas component if the admin bar is visible.
+	 * Adds inline styles for the offcanvas component if the admin bar is visible.
 	 *
-	 * Fixes that the offcanvas close icon is hidden behind the admin bar.
+	 * This function adjusts the top margin of the offcanvas component to
+	 * prevent it from being obscured by the WordPress admin bar.
 	 *
 	 * @since 1.2.0
+	 *
+	 * @global string $wp_version The WordPress version.
 	 */
 	function understrap_offcanvas_admin_bar_inline_styles() {
+		global $wp_version;
+
 		$navbar_type = get_theme_mod( 'understrap_navbar_type', 'collapse' );
 		if ( 'offcanvas' !== $navbar_type ) {
 			return;
 		}
 
-		$css = '
-		body.admin-bar .offcanvas.show  {
-			margin-top: 32px;
-		}
-		@media screen and ( max-width: 782px ) {
-			body.admin-bar .offcanvas.show {
-				margin-top: 46px;
+		if ( version_compare( $wp_version, '5.9', '>=' ) ) {
+			$css = '
+			body.admin-bar .offcanvas.show,
+			body.admin-bar .offcanvas.showing {
+				margin-top: var(--wp-admin--admin-bar--height);
+			}';
+		} else {
+			$css = '
+			body.admin-bar .offcanvas.show,
+			body.admin-bar .offcanvas.showing {
+				margin-top: 32px;
 			}
-		}';
+			@media screen and ( max-width: 782px ) {
+				body.admin-bar .offcanvas.show,
+				body.admin-bar .offcanvas.showing {
+					margin-top: 46px;
+				}
+			}';
+		}
+
 		wp_add_inline_style( 'understrap-styles', $css );
 	}
 }


### PR DESCRIPTION
## Description
This PR:
- Utilizes the custom property `--wp-admin--admin-bar--height` to add a top margin to the offcanvas component for WordPress 5.9 and newer versions, ensuring proper spacing beneath the admin bar.
- Introduces the `showing` class alongside the existing `show` class for the offcanvas component to enhance its positioning during sliding out.

## Motivation and Context
The height of the WordPress admin bar may change in the future or vary based on user customizations. Leveraging the custom property provided by WordPress ensures the use of the correct top margin for the offcanvas component, regardless of any adjustments by other themes or plugins. This method also removes the necessity for media queries tied to the admin bar's height.

The introduction of the `showing` class specifically addresses the transition phase of the offcanvas component. While the `show` class effectively styles the offcanvas in its final, slid-out state, the absence of intermediate transition styling lead to visual shifts. The `showing` class is applied during the sliding-out animation, applying the necessary styles to ensure a smooth transition. This addition prevents the offcanvas component from experiencing any downward shifts during activation, promoting a smoother and more visually consistent experience with the offcanvas menu.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (a code change that neither fixes a bug nor adds a feature)
- [ ] Styling (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
- [ ] Development (changes that affect the build system or external dependencies)
- [ ] Documentation (changes that affect existing inline documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I pulled my branch from `develop`.
- [x] I am submitting my pull request to `develop`.
- [x] I have resolved any conflicts merging this pull request would create.
- [x] I have checked that there aren't other open Pull Requests for the same update/change.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] \(Optional) My change requires a change to the documentation.
- [ ] \(Optional) I have updated the documentation accordingly.
- [ ] \(Optional) My change requires a change to the translations.
- [ ] \(Optional) I have updated the translations accordingly.
- [x] `composer phpcs` has passed locally.
- [x] `composer php-lint` has passed locally.
- [x] `composer phpmd` has passed locally.
- [x] `composer phpstan` has passed locally.
- [x] I have read the **[CONTRIBUTING](https://github.com/understrap/understrap/blob/main/.github/CONTRIBUTING.md)** document.

## Related Issues or Roadmap requests

## Further comments
Styles introduced in #1877
