### PR TITLE
Remove past entry about dependency updates

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -127,14 +127,6 @@ This is a bugfix and maintenance release.
   - Use get_theme_file_path() to make include files child theme friendly.
   - Fixes breaking child theme overloading /inc/ folder files.
 
-** Dependency Updates **
-  - Bump ws from 7.4.3 to 7.4.6
-  - Bump browserslist from 4.16.1 to 4.16.6
-  - Bump postcss from 8.2.9 to 8.2.10
-  - Bump hosted-git-info from 2.8.8 to 2.8.9
-  - Bump lodash from 4.17.20 to 4.17.21
-  - Bump ua-parser-js from 0.7.23 to 0.7.28
-
 
 ## Release 0.9.5 June 10th 2021
 This is a maintenance release incorporating many commits including code formatting and dependency updates that have occurred over the past two years. There are still many dependency updates remaining, and they will be addressed in new releases coming soon, but we want to get this release synced first.


### PR DESCRIPTION
See https://github.com/understrap/understrap/actions/runs/8515166522/job/23322131310

While this is a false positive, I see no reason to have dependency updates in the change log, especially if they do not change the build process.